### PR TITLE
[DNM] example: add fancy borders

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -143,10 +143,27 @@ vim.api.nvim_exec(
 -- Y yank until the end of line
 vim.api.nvim_set_keymap('n', 'Y', 'y$', { noremap = true })
 
+vim.cmd [[autocmd ColorScheme * highlight NormalFloat guibg=#1f2335]]
+vim.cmd [[autocmd ColorScheme * highlight FloatBorder guifg=white guibg=#1f2335]]
+
+local border = {
+      {"🭽", "FloatBorder"},
+      {"▔", "FloatBorder"},
+      {"🭾", "FloatBorder"},
+      {"▕", "FloatBorder"},
+      {"🭿", "FloatBorder"},
+      {"▁", "FloatBorder"},
+      {"🭼", "FloatBorder"},
+      {"▏", "FloatBorder"},
+}
+
 -- LSP settings
 local nvim_lsp = require 'lspconfig'
 local on_attach = function(_, bufnr)
   vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+  vim.lsp.handlers["textDocument/hover"] =  vim.lsp.with(vim.lsp.handlers.hover, {border = border})
+  vim.lsp.handlers["textDocument/signatureHelp"] =  vim.lsp.with(vim.lsp.handlers.hover, {border = border})
 
   local opts = { noremap = true, silent = true }
   vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gD', '<Cmd>lua vim.lsp.buf.declaration()<CR>', opts)
@@ -287,6 +304,9 @@ require('compe').setup {
     vsnip = false,
     ultisnips = false,
   },
+  documentation = {
+    border = border;
+  }
 }
 
 -- Utility functions for compe and luasnip


### PR DESCRIPTION
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/13316262/125878895-84d9f669-4d18-4d8b-9e98-3df2daa6dc29.png">

Note: You will need a modern font (I use Meslo LGS Nerd Font) and a modern terminal emulator (I use kitty)