### PR TITLE
update indent-blankline setup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -96,11 +96,11 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   pattern = '*',
 })
 
---Map blankline
-vim.g.indent_blankline_char = '┊'
-vim.g.indent_blankline_filetype_exclude = { 'help', 'packer' }
-vim.g.indent_blankline_buftype_exclude = { 'terminal', 'nofile' }
-vim.g.indent_blankline_show_trailing_blankline_indent = false
+-- Indent blankline
+require('indent_blankline').setup {
+  char = '┊',
+  show_trailing_blankline_indent = false,
+}
 
 -- Gitsigns
 require('gitsigns').setup {


### PR DESCRIPTION
- use the lua setup function
- remove `indent_blankline_filetype_exclude` and `indent_blankline_buftype_exclude` settings, as they are set by default now